### PR TITLE
Revert code back to v1.4.8

### DIFF
--- a/mobileVers/application/templates/application/quickApply.html
+++ b/mobileVers/application/templates/application/quickApply.html
@@ -10,7 +10,7 @@ the Free Software Foundation, either version 3 of the License, or
     <div class="content spaceAround">
         <!--NOTE: For the future have numbers change based on database-->
         {% if 'grocery' in programName|lower %}
-            <h1><b>Thank you for quick applying to the {{ programName }} program! The program runs each year between August and October; your application will be processed during that period.</b></h1>
+            <h1><b>Thank you for quick applying to the {{ programName }} program!</b></h1>
         {% else %}
             <h1><b>Thank you for quick applying to the {{ programName }} program! We'll let you know when you've been enrolled.</b></h1>
 


### PR DESCRIPTION
v1.4.9(_bad) had an erroneous wording change. This is a full reversion back to v1.4.8